### PR TITLE
SSL Fix

### DIFF
--- a/app/code/community/OlegKoval/ContactsFormCaptcha/controllers/IndexController.php
+++ b/app/code/community/OlegKoval/ContactsFormCaptcha/controllers/IndexController.php
@@ -38,7 +38,7 @@ class OlegKoval_ContactsFormCaptcha_IndexController extends Mage_Contacts_IndexC
             
             //create captcha html-code
             $publickey = Mage::getStoreConfig(self::XML_PATH_CFC_PUBLIC_KEY);
-            $captcha_code = recaptcha_get_html($publickey);
+            $captcha_code = recaptcha_get_html($publickey, null, Mage::app()->getStore()->isCurrentlySecure());
 
             //get reCaptcha theme name
             $theme = Mage::getStoreConfig(self::XML_PATH_CFC_THEME);


### PR DESCRIPTION
This way each store view can have SSL enabled or disabled on it's own and still have the module work across all storeviews. It checks the SSL state of the current storeview instead of the entire Magento installation.